### PR TITLE
Solution

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -14,4 +14,4 @@ def count_occurrences(phrase: str, letter: str) -> int:
     :param letter: letter to find occurrences of it
     :return: count occurrences of letter in phrase
     """
-    # write your code here
+    return phrase.lower().count(letter.lower())


### PR DESCRIPTION
I don't know if I did it right. I used these lines instead of these. I added a dot before the word (venv). Because PyCharm argued differently.

python -m venv venv
venv\Scripts\activate (on Windows)
pip install -r requirements.txt

python -m venv .venv
.venv\Scripts\activate (on Windows)
pip install -r requirements.txt

